### PR TITLE
Added minVersion tag

### DIFF
--- a/src/main/resources/tklib.mixin.json
+++ b/src/main/resources/tklib.mixin.json
@@ -1,5 +1,6 @@
 {
   "required": true,
+  "minVersion": "0.8",
   "package": "com.technicalitiesmc.lib.mixin",
   "compatibilityLevel": "JAVA_17",
   "mixins": [


### PR DESCRIPTION
I added the minVersion tag, so this error doesn't come up:
```
[main/ERROR]: Mixin config tklib.mixin.json does not specify "minVersion" property
```